### PR TITLE
Update main ui sidebar and submenus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,14 @@ import ContextsPage from './pages/contexts'
 import ContextDetailPage from './pages/contexts/[contextId]'
 import ApiTokensPage from './pages/api-tokens'
 import SharedViewerPage from './pages/shared'
-import AdminUsersPage from './pages/admin/users'
 import AdminWorkspacesPage from './pages/admin/workspaces'
+import AdminContextsPage from './pages/admin/contexts'
+import AdminAgentsPage from './pages/admin/agents'
+import AdminRolesPage from './pages/admin/roles'
 import AgentsPage from './pages/agents'
 import AgentDetailPage from './pages/agents/[agentId]'
+import RolesPage from './pages/roles'
+import RemotesPage from './pages/remotes'
 import { DashboardLayout } from './components/layouts/dashboard-layout'
 import { ToastContainer, useToast } from './components/ui/toast-container'
 import { setGlobalErrorHandler } from './lib/error-handler'
@@ -52,12 +56,16 @@ function AppContent() {
           <Route path="users/:userId/contexts/:contextId" element={<ContextDetailPage />} />
           <Route path="agents" element={<AgentsPage />} />
           <Route path="agents/:agentId" element={<AgentDetailPage />} />
+          <Route path="roles" element={<RolesPage />} />
+          <Route path="remotes" element={<RemotesPage />} />
           <Route path="api-tokens" element={<ApiTokensPage />} />
           <Route path="shared" element={<SharedViewerPage />} />
 
           {/* Admin routes */}
-          <Route path="admin/users" element={<AdminUsersPage />} />
+          <Route path="admin/contexts" element={<AdminContextsPage />} />
           <Route path="admin/workspaces" element={<AdminWorkspacesPage />} />
+          <Route path="admin/agents" element={<AdminAgentsPage />} />
+          <Route path="admin/roles" element={<AdminRolesPage />} />
         </Route>
 
         {/* Catch-all redirect to home */}

--- a/src/components/layouts/dashboard-layout.tsx
+++ b/src/components/layouts/dashboard-layout.tsx
@@ -1,13 +1,9 @@
 import { Outlet, useLocation, useNavigate } from "react-router-dom"
 import { useState, useEffect, useCallback } from "react"
-import { LogOut, LayoutGrid, Layers3, KeyRound, Infinity, ChevronRight, Users, FolderOpen, Brain } from "lucide-react"
+import { LogOut, LayoutGrid, Layers3, Settings, FolderOpen, Brain, Shield, Server } from "lucide-react"
 import { api } from "@/lib/api"
-import socketService from "@/lib/socket"
 import { useToast } from "@/components/ui/toast-container"
 import { getCurrentUserFromToken } from "@/services/auth"
-import { listWorkspaces } from "@/services/workspace"
-import { listContexts } from "@/services/context"
-import { listAgents, type Agent } from "@/services/agent"
 import {
   Sidebar,
   SidebarContent,
@@ -20,254 +16,25 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
   SidebarProvider,
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
 } from "@/components/ui/sidebar"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 
-// Workspace interface
-interface Workspace {
-  id: string
-  name: string
-  label: string
-  description: string
-  owner: string
-  color?: string | null
-  status: 'available' | 'not_found' | 'error' | 'active' | 'inactive' | 'removed' | 'destroyed'
-  type?: string
-  createdAt: string
-  updatedAt: string
-}
-
-// Context interface (from global types but redefined for local use)
-interface LocalContext {
-  id: string
-  url: string
-  description?: string
-  workspace?: string
-  baseUrl?: string
-  owner?: string
-  createdAt?: string
-  updatedAt?: string
-}
-
-// Agents interface for sidebar display
-interface LocalAgent {
-  id: string
-  name: string
-  label?: string
-  color?: string
-  isActive: boolean
-  status: string
-}
-
-// Navigation items (excluding workspaces and contexts which will be submenus)
-const navigationItems = [
-  {
-    title: "universe",
-    url: "/workspaces/universe",
-    icon: Infinity,
-    description: "universe"
-  }
-]
-
-// Separate component for sidebar content that uses useSidebar hook
+// Separate component for sidebar content
 function DashboardSidebar() {
   const location = useLocation()
   const navigate = useNavigate()
   const { showToast } = useToast()
-  const { state } = useSidebar()
   const [user, setUser] = useState<{ id: string; email: string; userType: string } | null>(null)
-  const [workspaces, setWorkspaces] = useState<Workspace[]>([])
-  const [isWorkspacesOpen, setIsWorkspacesOpen] = useState(true)
-  const [isLoadingWorkspaces, setIsLoadingWorkspaces] = useState(false)
-  const [contexts, setContexts] = useState<LocalContext[]>([])
-  const [isContextsOpen, setIsContextsOpen] = useState(true)
-  const [isLoadingContexts, setIsLoadingContexts] = useState(false)
-  const [agents, setAgents] = useState<LocalAgent[]>([])
-  const [isAgentsOpen, setIsAgentsOpen] = useState(true)
-  const [isLoadingAgents, setIsLoadingAgents] = useState(false)
 
   // Get user information from token
   useEffect(() => {
     const currentUser = getCurrentUserFromToken()
     setUser(currentUser)
-  }, [])
-
-  // Fetch workspaces
-  useEffect(() => {
-    const fetchWorkspaces = async () => {
-      setIsLoadingWorkspaces(true)
-      try {
-        const workspaceData = await listWorkspaces()
-        if (Array.isArray(workspaceData)) {
-          // Transform the API response to match our interface
-          const transformedData = workspaceData.map((ws: any) => ({
-            id: ws.id,
-            name: ws.name,
-            label: ws.label || ws.name,
-            description: ws.description,
-            owner: ws.owner,
-            color: ws.color,
-            status: ws.status,
-            type: ws.type,
-            createdAt: ws.created || ws.createdAt,
-            updatedAt: ws.updated || ws.updatedAt,
-          }))
-          setWorkspaces(transformedData)
-        } else {
-            console.warn('listWorkspaces response is not an array:', workspaceData);
-            setWorkspaces([]);
-        }
-      } catch (error) {
-        console.error('Failed to fetch workspaces:', error)
-
-        // Set empty array to prevent "A.map is not a function" errors
-        setWorkspaces([]);
-
-        showToast({
-          title: 'Error',
-          description: 'Failed to load workspaces',
-          variant: 'destructive'
-        })
-      } finally {
-        setIsLoadingWorkspaces(false)
-      }
-    }
-
-    fetchWorkspaces()
-  }, [])
-
-  // Fetch contexts
-  useEffect(() => {
-    const fetchContexts = async () => {
-      setIsLoadingContexts(true)
-      try {
-        const contextData = await listContexts()
-        if (Array.isArray(contextData)) {
-            setContexts(contextData)
-        } else {
-            console.warn('listContexts response is not an array:', contextData);
-            setContexts([]);
-        }
-      } catch (error) {
-        console.error('Failed to fetch contexts:', error)
-
-        // Set empty array to prevent "A.map is not a function" errors
-        setContexts([]);
-
-        showToast({
-          title: 'Error',
-          description: 'Failed to load contexts',
-          variant: 'destructive'
-        })
-      } finally {
-        setIsLoadingContexts(false)
-      }
-    }
-
-    fetchContexts()
-  }, [])
-
-  // Fetch agents
-  useEffect(() => {
-    const fetchAgents = async () => {
-      setIsLoadingAgents(true)
-      try {
-        const agentData = await listAgents()
-        if (Array.isArray(agentData)) {
-          // Transform the API response to match our interface
-          const transformedData: LocalAgent[] = agentData.map((agent: Agent) => ({
-            id: agent.id,
-            name: agent.name,
-            label: agent.label || agent.name,
-            color: agent.color,
-            isActive: agent.isActive,
-            status: agent.status
-          }))
-          setAgents(transformedData)
-        } else {
-          console.warn('listAgents response is not an array:', agentData);
-          setAgents([]);
-        }
-      } catch (error) {
-        console.error('Failed to fetch agents:', error)
-        setAgents([]);
-        showToast({
-          title: 'Error',
-          description: 'Failed to load agents',
-          variant: 'destructive'
-        })
-      } finally {
-        setIsLoadingAgents(false)
-      }
-    }
-
-    fetchAgents()
-  }, [])
-
-  // Keep workspaces and contexts in sync with real-time socket events so that the sidebar updates automatically
-  useEffect(() => {
-    if (!socketService.isConnected()) {
-      socketService.reconnect()
-    }
-
-    socketService.emit('subscribe', { channel: 'context' })
-    socketService.emit('subscribe', { channel: 'workspace' })
-
-    const handleContextCreated = (data: any) => {
-      if (!data || !data.id) return
-
-      setContexts(prev => {
-        if (prev.some(ctx => ctx.id === data.id)) {
-          return prev
-        }
-        return [...prev, data]
-      })
-    }
-
-    const handleContextDeleted = (data: { id?: string; contextId?: string }) => {
-      const deletedId = data.id ?? data.contextId
-      if (!deletedId) return
-      setContexts(prev => prev.filter(ctx => ctx.id !== deletedId))
-    }
-
-    const handleWorkspaceCreated = (data: any) => {
-      if (!data || !data.id) return
-      setWorkspaces(prev => {
-        if (prev.some(ws => ws.id === data.id)) {
-          return prev
-        }
-        return [...prev, { ...data, label: data.label || data.name }]
-      })
-    }
-
-    const handleWorkspaceDeleted = (data: { id?: string; workspaceId?: string }) => {
-      const deletedId = data.id ?? data.workspaceId
-      if (!deletedId) return
-      setWorkspaces(prev => prev.filter(ws => ws.id !== deletedId))
-    }
-
-    socketService.on('context:created', handleContextCreated)
-    socketService.on('context:deleted', handleContextDeleted)
-    socketService.on('workspace:created', handleWorkspaceCreated)
-    socketService.on('workspace:deleted', handleWorkspaceDeleted)
-
-    return () => {
-      socketService.emit('unsubscribe', { channel: 'context' })
-      socketService.emit('unsubscribe', { channel: 'workspace' })
-      socketService.off('context:created', handleContextCreated)
-      socketService.off('context:deleted', handleContextDeleted)
-      socketService.off('workspace:created', handleWorkspaceCreated)
-      socketService.off('workspace:deleted', handleWorkspaceDeleted)
-    }
   }, [])
 
   const isActive = (path: string) => {
@@ -289,14 +56,12 @@ function DashboardSidebar() {
     }
   }
 
-  // Safe navigation function that uses React Router
   const navigateTo = useCallback((path: string) => {
     if (location.pathname !== path) {
       navigate(path)
     }
   }, [location.pathname, navigate])
 
-  // Get user initials for avatar fallback
   const getUserInitials = (email: string) => {
     return email
       .split('@')[0]
@@ -305,6 +70,8 @@ function DashboardSidebar() {
       .join('')
       .slice(0, 2)
   }
+
+  const isAdmin = user?.userType === 'admin'
 
   return (
     <>
@@ -327,7 +94,6 @@ function DashboardSidebar() {
                   </div>
                   <div className="grid flex-1 text-left text-sm leading-tight">
                     <span className="truncate font-semibold">Canvas</span>
-
                   </div>
                 </button>
               </SidebarMenuButton>
@@ -339,168 +105,183 @@ function DashboardSidebar() {
           <SidebarGroup>
             <SidebarGroupContent>
               <SidebarMenu>
-                {navigationItems.map((item) => (
-                  <SidebarMenuItem key={item.title}>
-                    <SidebarMenuButton
-                      asChild
-                      isActive={isActive(item.url)}
-                      tooltip={item.description}
-                    >
-                      <button
-                        onClick={() => navigateTo(item.url)}
-                        className="flex items-center"
-                        type="button"
-                      >
-                        <item.icon className="size-4" />
-                        <span>{item.title}</span>
-                      </button>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))}
-
-                                {/* Workspaces submenu */}
+                {/* Main navigation items */}
                 <SidebarMenuItem>
                   <SidebarMenuButton
-                    onClick={() => {
-                      // If sidebar is collapsed, navigate to workspaces page
-                      if (state === 'collapsed') {
-                        navigateTo('/workspaces')
-                      } else {
-                        // If sidebar is expanded, toggle the submenu
-                        setIsWorkspacesOpen(!isWorkspacesOpen)
-                      }
-                    }}
+                    asChild
+                    isActive={isActive('/contexts')}
+                    tooltip="Manage your contexts"
+                  >
+                    <button
+                      onClick={() => navigateTo('/contexts')}
+                      className="flex items-center"
+                      type="button"
+                    >
+                      <Layers3 className="size-4" />
+                      <span>Contexts</span>
+                    </button>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={isActive('/workspaces')}
                     tooltip="Manage your workspaces"
                   >
-                    <LayoutGrid className="size-4" />
-                    <span>Workspaces</span>
-                    <ChevronRight
-                      className={`ml-auto size-4 transition-transform ${isWorkspacesOpen ? 'rotate-90' : ''}`}
-                    />
+                    <button
+                      onClick={() => navigateTo('/workspaces')}
+                      className="flex items-center"
+                      type="button"
+                    >
+                      <LayoutGrid className="size-4" />
+                      <span>Workspaces</span>
+                    </button>
                   </SidebarMenuButton>
-
-                  {isWorkspacesOpen && (
-                    <SidebarMenuSub>
-                      {/* Manage Workspaces link */}
-                      <SidebarMenuSubItem>
-                        <SidebarMenuSubButton
-                          asChild
-                          isActive={location.pathname === '/workspaces'}
-                        >
-                          <button
-                            onClick={() => navigateTo('/workspaces')}
-                            className="flex items-center"
-                            type="button"
-                          >
-                            <span>Manage Workspaces</span>
-                          </button>
-                        </SidebarMenuSubButton>
-                      </SidebarMenuSubItem>
-
-                                             {/* Individual workspaces */}
-                       {isLoadingWorkspaces ? (
-                         <SidebarMenuSubItem>
-                           <div className="px-2 py-1 text-xs text-muted-foreground">
-                             Loading...
-                           </div>
-                         </SidebarMenuSubItem>
-                       ) : (
-                         workspaces.map((workspace) => (
-                           <SidebarMenuSubItem key={`${workspace.owner}-${workspace.name}`}>
-                             <SidebarMenuSubButton
-                               asChild
-                               isActive={location.pathname === `/workspaces/${workspace.name}`}
-                             >
-                               <button
-                                 onClick={() => navigateTo(`/workspaces/${workspace.name}`)}
-                                 className="flex items-center relative"
-                                 type="button"
-                               >
-                                 {workspace.color && (
-                                   <div
-                                     className="absolute left-0 top-0 bottom-0 w-1 rounded-none"
-                                     style={{ backgroundColor: workspace.color, borderRadius: '0' }}
-                                   />
-                                 )}
-                                 <span className="truncate">{workspace.label}</span>
-                               </button>
-                             </SidebarMenuSubButton>
-                           </SidebarMenuSubItem>
-                         ))
-                       )}
-                    </SidebarMenuSub>
-                  )}
                 </SidebarMenuItem>
 
-                {/* Contexts submenu */}
                 <SidebarMenuItem>
                   <SidebarMenuButton
-                    onClick={() => {
-                      // If sidebar is collapsed, navigate to contexts page
-                      if (state === 'collapsed') {
-                        navigateTo('/contexts')
-                      } else {
-                        // If sidebar is expanded, toggle the submenu
-                        setIsContextsOpen(!isContextsOpen)
-                      }
-                    }}
-                    tooltip="Browse and manage contexts"
+                    asChild
+                    isActive={isActive('/agents')}
+                    tooltip="Manage your AI agents"
                   >
-                    <Layers3 className="size-4" />
-                    <span>Contexts</span>
-                    <ChevronRight
-                      className={`ml-auto size-4 transition-transform ${isContextsOpen ? 'rotate-90' : ''}`}
-                    />
+                    <button
+                      onClick={() => navigateTo('/agents')}
+                      className="flex items-center"
+                      type="button"
+                    >
+                      <Brain className="size-4" />
+                      <span>Agents</span>
+                    </button>
                   </SidebarMenuButton>
-
-                  {isContextsOpen && (
-                    <SidebarMenuSub>
-                      {/* Manage Contexts link */}
-                      <SidebarMenuSubItem>
-                        <SidebarMenuSubButton
-                          asChild
-                          isActive={location.pathname === '/contexts'}
-                        >
-                          <button
-                            onClick={() => navigateTo('/contexts')}
-                            className="flex items-center"
-                            type="button"
-                          >
-                            <span>Manage Contexts</span>
-                          </button>
-                        </SidebarMenuSubButton>
-                      </SidebarMenuSubItem>
-
-                      {/* Individual contexts */}
-                      {isLoadingContexts ? (
-                        <SidebarMenuSubItem>
-                          <div className="px-2 py-1 text-xs text-muted-foreground">
-                            Loading...
-                          </div>
-                        </SidebarMenuSubItem>
-                      ) : (
-                        contexts.map((context) => (
-                          <SidebarMenuSubItem key={`${context.owner || 'unknown'}-${context.id}`}>
-                            <SidebarMenuSubButton
-                              asChild
-                              isActive={location.pathname === `/contexts/${context.id}`}
-                            >
-                              <button
-                                onClick={() => navigateTo(`/contexts/${context.id}`)}
-                                className="flex items-center"
-                                type="button"
-                              >
-                                <span className="truncate">{context.url || context.id}</span>
-                              </button>
-                            </SidebarMenuSubButton>
-                          </SidebarMenuSubItem>
-                        ))
-                      )}
-                    </SidebarMenuSub>
-                  )}
                 </SidebarMenuItem>
 
-                {/* API Keys */}
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={isActive('/roles')}
+                    tooltip="Manage roles (coming soon)"
+                  >
+                    <button
+                      onClick={() => navigateTo('/roles')}
+                      className="flex items-center"
+                      type="button"
+                    >
+                      <Shield className="size-4" />
+                      <span>Roles</span>
+                    </button>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={isActive('/remotes')}
+                    tooltip="Manage remotes (coming soon)"
+                  >
+                    <button
+                      onClick={() => navigateTo('/remotes')}
+                      className="flex items-center"
+                      type="button"
+                    >
+                      <Server className="size-4" />
+                      <span>Remotes</span>
+                    </button>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+
+          <SidebarSeparator />
+
+          {/* Admin section */}
+          {isAdmin && (
+            <>
+              <SidebarGroup>
+                <SidebarGroupLabel>Administration</SidebarGroupLabel>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={isActive('/admin/contexts')}
+                        tooltip="Manage all contexts"
+                      >
+                        <button
+                          onClick={() => navigateTo('/admin/contexts')}
+                          className="flex items-center"
+                          type="button"
+                        >
+                          <Layers3 className="size-4" />
+                          <span>All Contexts</span>
+                        </button>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={isActive('/admin/workspaces')}
+                        tooltip="Manage all workspaces"
+                      >
+                        <button
+                          onClick={() => navigateTo('/admin/workspaces')}
+                          className="flex items-center"
+                          type="button"
+                        >
+                          <FolderOpen className="size-4" />
+                          <span>All Workspaces</span>
+                        </button>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={isActive('/admin/agents')}
+                        tooltip="Manage all agents"
+                      >
+                        <button
+                          onClick={() => navigateTo('/admin/agents')}
+                          className="flex items-center"
+                          type="button"
+                        >
+                          <Brain className="size-4" />
+                          <span>All Agents</span>
+                        </button>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={isActive('/admin/roles')}
+                        tooltip="Manage all roles (coming soon)"
+                      >
+                        <button
+                          onClick={() => navigateTo('/admin/roles')}
+                          className="flex items-center"
+                          type="button"
+                        >
+                          <Shield className="size-4" />
+                          <span>All Roles</span>
+                        </button>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </SidebarGroup>
+
+              <SidebarSeparator />
+            </>
+          )}
+
+          {/* Settings section */}
+          <SidebarGroup>
+            <SidebarGroupContent>
+              <SidebarMenu>
                 <SidebarMenuItem>
                   <SidebarMenuButton
                     asChild
@@ -512,131 +293,11 @@ function DashboardSidebar() {
                       className="flex items-center"
                       type="button"
                     >
-                      <KeyRound className="size-4" />
-                      <span>API Keys</span>
+                      <Settings className="size-4" />
+                      <span>Settings</span>
                     </button>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
-
-                {/* Agents submenu */}
-                <SidebarMenuItem>
-                  <SidebarMenuButton
-                    onClick={() => {
-                      // If sidebar is collapsed, navigate to agents page
-                      if (state === 'collapsed') {
-                        navigateTo('/agents')
-                      } else {
-                        // If sidebar is expanded, toggle the submenu
-                        setIsAgentsOpen(!isAgentsOpen)
-                      }
-                    }}
-                    tooltip="Manage your AI agents"
-                  >
-                    <Brain className="size-4" />
-                    <span>Agents</span>
-                    <ChevronRight
-                      className={`ml-auto size-4 transition-transform ${isAgentsOpen ? 'rotate-90' : ''}`}
-                    />
-                  </SidebarMenuButton>
-
-                  {isAgentsOpen && (
-                    <SidebarMenuSub>
-                      {/* Manage Agents link */}
-                      <SidebarMenuSubItem>
-                        <SidebarMenuSubButton
-                          asChild
-                          isActive={location.pathname === '/agents'}
-                        >
-                          <button
-                            onClick={() => navigateTo('/agents')}
-                            className="flex items-center"
-                            type="button"
-                          >
-                            <span>Manage Agents</span>
-                          </button>
-                        </SidebarMenuSubButton>
-                      </SidebarMenuSubItem>
-
-                      {/* Individual agents */}
-                      {isLoadingAgents ? (
-                        <SidebarMenuSubItem>
-                          <div className="px-2 py-1 text-xs text-muted-foreground">
-                            Loading...
-                          </div>
-                        </SidebarMenuSubItem>
-                      ) : (
-                        agents.map((agent) => (
-                          <SidebarMenuSubItem key={agent.id}>
-                            <SidebarMenuSubButton
-                              asChild
-                              isActive={location.pathname === `/agents/${agent.name}`}
-                            >
-                              <button
-                                onClick={() => navigateTo(`/agents/${agent.name}`)}
-                                className="flex items-center relative"
-                                type="button"
-                              >
-                                {agent.color && (
-                                  <div
-                                    className="absolute left-0 top-0 bottom-0 w-1 rounded-none"
-                                    style={{ backgroundColor: agent.color, borderRadius: '0' }}
-                                  />
-                                )}
-                                <div
-                                  className={`w-2 h-2 rounded-full mr-2 flex-shrink-0 ${
-                                    agent.isActive ? 'bg-green-500' : 'bg-gray-400'
-                                  }`}
-                                />
-                                <span className="truncate">{agent.label}</span>
-                              </button>
-                            </SidebarMenuSubButton>
-                          </SidebarMenuSubItem>
-                        ))
-                      )}
-                    </SidebarMenuSub>
-                  )}
-                </SidebarMenuItem>
-
-                {/* Admin Section - Only visible to admin users */}
-                {user?.userType === 'admin' && (
-                  <>
-                    <SidebarGroupLabel>Administration</SidebarGroupLabel>
-
-                    <SidebarMenuItem>
-                      <SidebarMenuButton
-                        asChild
-                        isActive={isActive('/admin/users')}
-                        tooltip="Manage users"
-                      >
-                        <button
-                          onClick={() => navigateTo('/admin/users')}
-                          className="flex items-center"
-                          type="button"
-                        >
-                          <Users className="size-4" />
-                          <span>User Management</span>
-                        </button>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-
-                    <SidebarMenuItem>
-                      <SidebarMenuButton
-                        asChild
-                        isActive={isActive('/admin/workspaces')}
-                        tooltip="Manage workspaces for all users"
-                      >
-                        <button
-                          onClick={() => navigateTo('/admin/workspaces')}
-                          className="flex items-center"
-                          type="button"
-                        >
-                          <FolderOpen className="size-4" />
-                          <span>Workspace Administration</span>
-                        </button>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  </>
-                )}
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
@@ -704,15 +365,19 @@ function DashboardSidebar() {
               <span className="font-medium text-foreground">
                 {location.pathname === '/home' && 'Home'}
                 {location.pathname === '/workspaces' && 'Workspaces'}
-                {location.pathname.startsWith('/workspaces/') && location.pathname !== '/workspaces' && 'Workspace Details (read-only)'}
+                {location.pathname.startsWith('/workspaces/') && location.pathname !== '/workspaces' && 'Workspace Details'}
                 {location.pathname === '/contexts' && 'Contexts'}
                 {location.pathname.startsWith('/contexts/') && location.pathname !== '/contexts' && 'Context Details'}
                 {location.pathname.startsWith('/users/') && location.pathname.includes('/contexts/') && 'Shared Context Details'}
-                {location.pathname === '/api-tokens' && 'API Tokens'}
+                {location.pathname === '/api-tokens' && 'Settings'}
                 {location.pathname === '/agents' && 'Agents'}
                 {location.pathname.startsWith('/agents/') && location.pathname !== '/agents' && 'Agent Details'}
-                {location.pathname === '/admin/users' && 'User Management'}
-                {location.pathname === '/admin/workspaces' && 'Workspace Administration'}
+                {location.pathname === '/roles' && 'Roles'}
+                {location.pathname === '/remotes' && 'Remotes'}
+                {location.pathname === '/admin/contexts' && 'All Contexts'}
+                {location.pathname === '/admin/workspaces' && 'All Workspaces'}
+                {location.pathname === '/admin/agents' && 'All Agents'}
+                {location.pathname === '/admin/roles' && 'All Roles'}
               </span>
             </nav>
           </div>

--- a/src/pages/admin/agents/index.tsx
+++ b/src/pages/admin/agents/index.tsx
@@ -1,0 +1,21 @@
+export default function AdminAgentsPage() {
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="border-b pb-4">
+        <h1 className="text-3xl font-bold tracking-tight">All Agents</h1>
+        <p className="text-muted-foreground mt-2">Manage all AI agents across all users</p>
+      </div>
+
+      {/* Coming Soon Section */}
+      <div className="flex flex-col items-center justify-center py-12 space-y-4">
+        <div className="text-center">
+          <h2 className="text-2xl font-semibold mb-2">Coming Soon</h2>
+          <p className="text-muted-foreground max-w-md">
+            Global agent management is currently under development. Check back later for updates.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/admin/contexts/index.tsx
+++ b/src/pages/admin/contexts/index.tsx
@@ -1,0 +1,21 @@
+export default function AdminContextsPage() {
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="border-b pb-4">
+        <h1 className="text-3xl font-bold tracking-tight">All Contexts</h1>
+        <p className="text-muted-foreground mt-2">Manage all contexts across all users</p>
+      </div>
+
+      {/* Coming Soon Section */}
+      <div className="flex flex-col items-center justify-center py-12 space-y-4">
+        <div className="text-center">
+          <h2 className="text-2xl font-semibold mb-2">Coming Soon</h2>
+          <p className="text-muted-foreground max-w-md">
+            Global context management is currently under development. Check back later for updates.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/admin/roles/index.tsx
+++ b/src/pages/admin/roles/index.tsx
@@ -1,0 +1,21 @@
+export default function AdminRolesPage() {
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="border-b pb-4">
+        <h1 className="text-3xl font-bold tracking-tight">All Roles</h1>
+        <p className="text-muted-foreground mt-2">Manage all roles and permissions</p>
+      </div>
+
+      {/* Coming Soon Section */}
+      <div className="flex flex-col items-center justify-center py-12 space-y-4">
+        <div className="text-center">
+          <h2 className="text-2xl font-semibold mb-2">Coming Soon</h2>
+          <p className="text-muted-foreground max-w-md">
+            Global role management is currently under development. Check back later for updates.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/remotes/index.tsx
+++ b/src/pages/remotes/index.tsx
@@ -1,0 +1,21 @@
+export default function RemotesPage() {
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="border-b pb-4">
+        <h1 className="text-3xl font-bold tracking-tight">Remotes</h1>
+        <p className="text-muted-foreground mt-2">Connect to remote Canvas instances</p>
+      </div>
+
+      {/* Coming Soon Section */}
+      <div className="flex flex-col items-center justify-center py-12 space-y-4">
+        <div className="text-center">
+          <h2 className="text-2xl font-semibold mb-2">Coming Soon</h2>
+          <p className="text-muted-foreground max-w-md">
+            Remote connection management is currently under development. Check back later for updates.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/roles/index.tsx
+++ b/src/pages/roles/index.tsx
@@ -1,0 +1,21 @@
+export default function RolesPage() {
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="border-b pb-4">
+        <h1 className="text-3xl font-bold tracking-tight">Roles</h1>
+        <p className="text-muted-foreground mt-2">Manage user roles and permissions</p>
+      </div>
+
+      {/* Coming Soon Section */}
+      <div className="flex flex-col items-center justify-center py-12 space-y-4">
+        <div className="text-center">
+          <h2 className="text-2xl font-semibold mb-2">Coming Soon</h2>
+          <p className="text-muted-foreground max-w-md">
+            Role management functionality is currently under development. Check back later for updates.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Reworks the main UI sidebar to a simplified, flat navigation structure, improving UX by removing nested submenus and adding new top-level items for user and admin management.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee1a1f75-05cb-4c62-8702-0277259de6b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee1a1f75-05cb-4c62-8702-0277259de6b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Flattens the dashboard sidebar and adds new routes/pages for `roles`, `remotes`, and admin `contexts/agents/roles`, while updating headers and replacing API Tokens label with Settings.
> 
> - **UI/Navigation**:
>   - Simplified sidebar to flat navigation with top-level items: `Contexts`, `Workspaces`, `Agents`, `Roles`, `Remotes`.
>   - Added admin section (visible for admins) with `All Contexts`, `All Workspaces`, `All Agents`, `All Roles`.
>   - Renamed header labels (e.g., `Workspace Details`; `Settings` replaces `API Tokens`).
> - **Routing**:
>   - Added routes: `/roles`, `/remotes`, `/admin/contexts`, `/admin/agents`, `/admin/roles`.
>   - Removed `/admin/users` route.
> - **Pages**:
>   - New placeholder pages: `src/pages/roles`, `src/pages/remotes`, `src/pages/admin/contexts`, `src/pages/admin/agents`, `src/pages/admin/roles` (all "Coming Soon").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcb713846488a85d9eef82541250fcb2bef7f2aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->