### PR TITLE
Fix admin authorization and submenu display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import AdminWorkspacesPage from './pages/admin/workspaces'
 import AdminContextsPage from './pages/admin/contexts'
 import AdminAgentsPage from './pages/admin/agents'
 import AdminRolesPage from './pages/admin/roles'
+import AdminUsersPage from './pages/admin/users'
 import AgentsPage from './pages/agents'
 import AgentDetailPage from './pages/agents/[agentId]'
 import RolesPage from './pages/roles'
@@ -62,6 +63,7 @@ function AppContent() {
           <Route path="shared" element={<SharedViewerPage />} />
 
           {/* Admin routes */}
+          <Route path="admin/users" element={<AdminUsersPage />} />
           <Route path="admin/contexts" element={<AdminContextsPage />} />
           <Route path="admin/workspaces" element={<AdminWorkspacesPage />} />
           <Route path="admin/agents" element={<AdminAgentsPage />} />

--- a/src/components/layouts/dashboard-layout.tsx
+++ b/src/components/layouts/dashboard-layout.tsx
@@ -41,6 +41,8 @@ function DashboardSidebar() {
   const [workspaces, setWorkspaces] = useState<any[]>([])
   const [isLoadingContexts, setIsLoadingContexts] = useState(false)
   const [isLoadingWorkspaces, setIsLoadingWorkspaces] = useState(false)
+  const [hasFetchedContexts, setHasFetchedContexts] = useState(false)
+  const [hasFetchedWorkspaces, setHasFetchedWorkspaces] = useState(false)
 
   // Get user information from token
   useEffect(() => {
@@ -50,33 +52,37 @@ function DashboardSidebar() {
 
   // Fetch contexts when submenu opens
   useEffect(() => {
-    if (contextsOpen && contexts.length === 0 && !isLoadingContexts) {
+    if (contextsOpen && !hasFetchedContexts && !isLoadingContexts) {
       setIsLoadingContexts(true)
       listContexts()
         .then(data => {
           setContexts(data || [])
+          setHasFetchedContexts(true)
         })
         .catch(err => {
           console.error('Failed to fetch contexts:', err)
+          setHasFetchedContexts(true)
         })
         .finally(() => setIsLoadingContexts(false))
     }
-  }, [contextsOpen, contexts.length, isLoadingContexts])
+  }, [contextsOpen, hasFetchedContexts, isLoadingContexts])
 
   // Fetch workspaces when submenu opens
   useEffect(() => {
-    if (workspacesOpen && workspaces.length === 0 && !isLoadingWorkspaces) {
+    if (workspacesOpen && !hasFetchedWorkspaces && !isLoadingWorkspaces) {
       setIsLoadingWorkspaces(true)
       listWorkspaces()
         .then(data => {
           setWorkspaces(data || [])
+          setHasFetchedWorkspaces(true)
         })
         .catch(err => {
           console.error('Failed to fetch workspaces:', err)
+          setHasFetchedWorkspaces(true)
         })
         .finally(() => setIsLoadingWorkspaces(false))
     }
-  }, [workspacesOpen, workspaces.length, isLoadingWorkspaces])
+  }, [workspacesOpen, hasFetchedWorkspaces, isLoadingWorkspaces])
 
   const isActive = (path: string) => {
     return location.pathname === path || location.pathname.startsWith(path + "/")
@@ -155,8 +161,11 @@ function DashboardSidebar() {
                   >
                     <button
                       onClick={() => {
+                        const wasOpen = contextsOpen
                         setContextsOpen(!contextsOpen)
-                        navigateTo('/contexts')
+                        if (!wasOpen) {
+                          navigateTo('/contexts')
+                        }
                       }}
                       className="flex items-center justify-between w-full"
                       type="button"
@@ -216,8 +225,11 @@ function DashboardSidebar() {
                   >
                     <button
                       onClick={() => {
+                        const wasOpen = workspacesOpen
                         setWorkspacesOpen(!workspacesOpen)
-                        navigateTo('/workspaces')
+                        if (!wasOpen) {
+                          navigateTo('/workspaces')
+                        }
                       }}
                       className="flex items-center justify-between w-full"
                       type="button"

--- a/src/pages/admin/agents/index.tsx
+++ b/src/pages/admin/agents/index.tsx
@@ -1,4 +1,24 @@
+import { useEffect } from "react"
+import { getCurrentUserFromToken } from "@/services/auth"
+
 export default function AdminAgentsPage() {
+  const currentUser = getCurrentUserFromToken()
+  const isCurrentUserAdmin = currentUser?.userType === 'admin'
+
+  useEffect(() => {
+    if (!isCurrentUserAdmin) {
+      // Access denied - component will render error message
+    }
+  }, [isCurrentUserAdmin])
+
+  if (!isCurrentUserAdmin) {
+    return (
+      <div className="text-center space-y-4">
+        <div className="text-destructive">Access denied. Admin privileges required.</div>
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-6">
       {/* Page Header */}

--- a/src/pages/admin/contexts/index.tsx
+++ b/src/pages/admin/contexts/index.tsx
@@ -1,4 +1,24 @@
+import { useEffect } from "react"
+import { getCurrentUserFromToken } from "@/services/auth"
+
 export default function AdminContextsPage() {
+  const currentUser = getCurrentUserFromToken()
+  const isCurrentUserAdmin = currentUser?.userType === 'admin'
+
+  useEffect(() => {
+    if (!isCurrentUserAdmin) {
+      // Access denied - component will render error message
+    }
+  }, [isCurrentUserAdmin])
+
+  if (!isCurrentUserAdmin) {
+    return (
+      <div className="text-center space-y-4">
+        <div className="text-destructive">Access denied. Admin privileges required.</div>
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-6">
       {/* Page Header */}

--- a/src/pages/admin/roles/index.tsx
+++ b/src/pages/admin/roles/index.tsx
@@ -1,4 +1,24 @@
+import { useEffect } from "react"
+import { getCurrentUserFromToken } from "@/services/auth"
+
 export default function AdminRolesPage() {
+  const currentUser = getCurrentUserFromToken()
+  const isCurrentUserAdmin = currentUser?.userType === 'admin'
+
+  useEffect(() => {
+    if (!isCurrentUserAdmin) {
+      // Access denied - component will render error message
+    }
+  }, [isCurrentUserAdmin])
+
+  if (!isCurrentUserAdmin) {
+    return (
+      <div className="text-center space-y-4">
+        <div className="text-destructive">Access denied. Admin privileges required.</div>
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-6">
       {/* Page Header */}


### PR DESCRIPTION
Implement admin authorization for new admin pages, restore the admin user management route, and add dynamic submenus for Contexts and Workspaces.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec79baca-5b4b-4d76-8517-4e34c868d376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec79baca-5b4b-4d76-8517-4e34c868d376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds admin authorization to admin pages, restores `admin/users` route, and introduces dynamic expandable submenus for `Contexts` and `Workspaces` in the sidebar.
> 
> - **Routing**:
>   - Import and enable `AdminUsersPage`; add route `admin/users` in `src/App.tsx`.
> - **Admin pages** (`admin/agents`, `admin/contexts`, `admin/roles`):
>   - Add auth guard using `getCurrentUserFromToken`; non-admins see an access denied message.
> - **Sidebar UI** (`components/layouts/dashboard-layout.tsx`):
>   - Add expandable submenus for `Contexts` and `Workspaces` with chevrons, “All …” entries, loading states, and top-10 dynamic items fetched via `listContexts`/`listWorkspaces`.
>   - Add Admin “All Users” nav item and header label `User Management`.
>   - Import necessary icons and submenu components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82f29c16887fc1e41354ec905567f16633911354. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->