### PR TITLE
Tree view and document details

### DIFF
--- a/src/components/common/document-list.tsx
+++ b/src/components/common/document-list.tsx
@@ -274,6 +274,7 @@ function ImportModal({ isOpen, onClose, onImport }: ImportModalProps) {
 }
 
 function DocumentDetailModal({ document, isOpen, onClose }: DocumentDetailModalProps) {
+  const [showRawJson, setShowRawJson] = useState(false)
   if (!isOpen || !document) return null
 
   const formatDate = (dateString: string) => {
@@ -296,7 +297,12 @@ function DocumentDetailModal({ document, isOpen, onClose }: DocumentDetailModalP
               <h2 className="text-2xl font-bold">Document Details</h2>
               <p className="text-muted-foreground">ID: {document.id}</p>
             </div>
-            <button onClick={onClose} className="p-2 hover:bg-muted rounded-sm" title="Close">✕</button>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={() => setShowRawJson(v => !v)}>
+                {showRawJson ? 'View Data' : 'View Raw JSON'}
+              </Button>
+              <button onClick={onClose} className="p-2 hover:bg-muted rounded-sm" title="Close">✕</button>
+            </div>
           </div>
 
           <div className="space-y-6">
@@ -312,8 +318,8 @@ function DocumentDetailModal({ document, isOpen, onClose }: DocumentDetailModalP
             </div>
 
             <div>
-              <h3 className="font-semibold mb-3">Document Data</h3>
-              <pre className="bg-muted p-4 rounded-lg text-sm overflow-x-auto">{JSON.stringify(document.data, null, 2)}</pre>
+              <h3 className="font-semibold mb-3">{showRawJson ? 'Raw Document JSON' : 'Document Data'}</h3>
+              <pre className="bg-muted p-4 rounded-lg text-sm overflow-x-auto">{JSON.stringify(showRawJson ? document : document.data, null, 2)}</pre>
             </div>
 
             <div>

--- a/src/components/common/tree-view.tsx
+++ b/src/components/common/tree-view.tsx
@@ -597,6 +597,7 @@ export function TreeView({
     if (!onMovePath && !onCopyPath) return false
 
     const { mode, paths } = internalClipboard
+    let didSomething = false
 
     for (const fromPath of paths) {
       if (!fromPath || fromPath === targetPath) continue
@@ -604,11 +605,16 @@ export function TreeView({
       if (mode === 'cut') {
         if (!onMovePath) return false
         await onMovePath(fromPath, targetPath, false)
+        didSomething = true
       } else {
         if (!onCopyPath) return false
         await onCopyPath(fromPath, targetPath, false)
+        didSomething = true
       }
     }
+
+    // Don't clear clipboard if paste was effectively a no-op (e.g. cut /a then paste onto /a)
+    if (!didSomething) return false
 
     if (mode === 'cut') {
       setInternalClipboard(null)

--- a/src/components/context/document-detail-modal.tsx
+++ b/src/components/context/document-detail-modal.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
@@ -46,6 +47,7 @@ interface DocumentDetailModalProps {
 }
 
 export function DocumentDetailModal({ document, isOpen, onClose }: DocumentDetailModalProps) {
+  const [showRawJson, setShowRawJson] = useState(false);
   if (!isOpen || !document) return null;
 
   const formatDate = (dateString: string) => {
@@ -69,15 +71,25 @@ export function DocumentDetailModal({ document, isOpen, onClose }: DocumentDetai
               <h2 className="text-2xl font-bold">Document Details</h2>
               <p className="text-muted-foreground">ID: {document.id}</p>
             </div>
-            <Button
-              onClick={onClose}
-              variant="ghost"
-              size="sm"
-              className="p-2"
-              title="Close"
-            >
-              <X className="h-4 w-4" />
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                onClick={() => setShowRawJson(v => !v)}
+                variant="outline"
+                size="sm"
+                title="Toggle raw JSON view"
+              >
+                {showRawJson ? 'View Data' : 'View Raw JSON'}
+              </Button>
+              <Button
+                onClick={onClose}
+                variant="ghost"
+                size="sm"
+                className="p-2"
+                title="Close"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
           </div>
 
           {/* Content */}
@@ -107,9 +119,9 @@ export function DocumentDetailModal({ document, isOpen, onClose }: DocumentDetai
 
             {/* Document Data */}
             <div>
-              <h3 className="font-semibold mb-3">Document Data</h3>
+              <h3 className="font-semibold mb-3">{showRawJson ? 'Raw Document JSON' : 'Document Data'}</h3>
               <pre className="bg-muted p-4 rounded-lg text-sm overflow-x-auto">
-                {JSON.stringify(document.data, null, 2)}
+                {JSON.stringify(showRawJson ? document : document.data, null, 2)}
               </pre>
             </div>
 

--- a/src/pages/workspaces/[workspaceName]/index.tsx
+++ b/src/pages/workspaces/[workspaceName]/index.tsx
@@ -47,7 +47,6 @@ export default function WorkspaceDetailPage() {
   const [schemas, setSchemas] = useState<string[]>([]);
   const [selectedSchemas, setSelectedSchemas] = useState<string[]>([]);
   const [isLoadingSchemas, setIsLoadingSchemas] = useState(false);
-  const [treeVersion, setTreeVersion] = useState(0);
 
   // URL-based features and filters
   const [urlFilters, setUrlFilters] = useState<UrlFilters>({ features: [], filters: [] });
@@ -126,7 +125,6 @@ export default function WorkspaceDetailPage() {
     try {
       const response = await getWorkspaceTree(workspaceName);
       setTree(response.payload as TreeNode);
-      setTreeVersion(prev => prev + 1); // Force tree re-render
       setError(null);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch workspace tree';
@@ -829,7 +827,6 @@ export default function WorkspaceDetailPage() {
 
         {/* Enhanced File Manager */}
         <FileManagerView
-          key={`workspace-tree-${treeVersion}`}
           tree={tree}
           selectedPath={selectedPath}
           onPathSelect={(path: string) => {


### PR DESCRIPTION
Implements tree view cut/copy/paste, Ctrl-drag copy, preserves tree state on rename, and adds a raw JSON view for documents to improve usability.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a594ef4-5871-4e2c-b773-8bd1b35a9f7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a594ef4-5871-4e2c-b773-8bd1b35a9f7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves tree operations and document inspection across context pages.
> 
> - **TreeView**: Adds internal path clipboard fallback (`copy`/`cut`/`paste`), enables `copyMove` drag with Ctrl for copy, validates drops, adds keyboard shortcuts (Ctrl/Cmd+C/X/V), focusable container for shortcuts, and wires effective clipboard/paste handlers through `ContextMenu` and child nodes. Supports pasting dragged documents into paths.
> - **Document details**: Adds a toggle to view either `Document Data` or full `Raw Document JSON` in both `common/document-list` and `context/document-detail-modal`.
> - **Context views**: Implements `onRenamePath` via `renameWorkspaceLayer`, refreshes tree, updates selection for renamed subtrees, and removes forced re-render keys to preserve expansion state. Also passes `onRenamePath` to `TreeView` and integrates document list actions/pagination in the contexts page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f7303afd3b03ee4a4d3321348e10202487fc522. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->